### PR TITLE
added rabbitmq for intercommunication between post and history

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ DATABASE_HOST=127.0.0.1
 
 # MUST match the Gateway JWT policy and Auth's ACCESS_SECRET
 JWT_SECRET=
+
+# RabbitMQ (producer)
+RABBITMQ_URL=amqp://guest:guest@localhost:5672/
+RABBITMQ_EVENTS_EXCHANGE=fa.events
+RABBITMQ_EVENTS_EXCHANGE_TYPE=topic
 ```
 
 
@@ -122,3 +127,144 @@ The API returns standard HTTP status codes to indicate the outcome of requests. 
 | 404  | Not Found             | Post or Reply not found (or reply not under the specified post).                                       |
 | 409  | Conflict              | Reserved; not typically used by current endpoints.                                                      |
 | 500  | Internal Server Error | Unexpected server error.                                                                                |
+
+---
+
+## RabbitMQ Integration Testing
+
+This section provides comprehensive instructions for testing the complete RabbitMQ producer-consumer flow between `fa-post` (producer) and `fa-history` (consumer) services.
+
+### Architecture Overview
+
+```
+fa-post (Producer) → RabbitMQ → fa-history (Consumer) → MongoDB
+```
+
+**Core Events (for integration validation):**
+- `post.created` — new post created
+- `post.published` — post moved to Published
+- `post.updated` — post content/title updated
+- `post.deleted` — post soft deleted
+
+### 1. Prerequisites Setup Instructions
+
+#### 1.1 Start RabbitMQ using Docker
+
+```bash
+# Start RabbitMQ with management UI
+docker run -d --name rabbitmq-dev \
+  -p 5672:5672 \
+  -p 15672:15672 \
+  -e RABBITMQ_DEFAULT_USER=guest \
+  -e RABBITMQ_DEFAULT_PASS=guest \
+  rabbitmq:3-management
+
+# Verify RabbitMQ is running
+curl -s http://localhost:15672
+# Management UI: http://localhost:15672 (guest/guest)
+```
+
+#### 1.2 Start MongoDB for fa-history Service (Docker)
+
+```bash
+# Start local MongoDB (no auth)
+docker run -d --name mongodb-dev \
+  -p 27017:27017 \
+  mongo:6
+
+# Connection string used by fa-history: mongodb://localhost:27017/
+```
+
+#### 1.3 Configure MySQL for fa-post Service
+
+Ensure MySQL is running and accessible:
+```bash
+# Test MySQL connection
+mysql -u root -p -e "SELECT 1;"
+
+# Create database if not exists
+mysql -u root -p -e "CREATE DATABASE IF NOT EXISTS forum_app;"
+```
+
+#### 1.4 Environment Variable Configuration
+
+**fa-post/.env:**
+```ini
+PORT=3002
+DATABASE_NAME=forum_app
+DATABASE_USER=root
+DATABASE_PASSWORD=your_password
+DATABASE_HOST=localhost
+JWT_SECRET=devsecret
+
+# RabbitMQ Producer
+RABBITMQ_URL=amqp://guest:guest@localhost:5672/
+RABBITMQ_EVENTS_EXCHANGE=fa.events
+RABBITMQ_EVENTS_EXCHANGE_TYPE=topic
+```
+
+**fa-history/.env:**
+```ini
+PORT=3004
+JWT_SECRET=devsecret
+
+# MongoDB (Atlas or local)
+MONGODB_URI=mongodb://localhost:27017/
+MONGODB_DB=forum_history
+
+# RabbitMQ Consumer
+RABBITMQ_URL=amqp://guest:guest@localhost:5672/
+EVENTS_EXCHANGE=fa.events
+EVENTS_EXCHANGE_TYPE=topic
+EVENTS_QUEUE=fa-history.events
+EVENTS_ROUTING_KEY=post.*
+EVENTS_CONSUMER_ENABLED=true
+RABBITMQ_PREFETCH=10
+```
+
+### 2. Service Startup Instructions
+
+#### 2.1 Start fa-history Consumer Service
+
+```bash
+# Terminal 1: Start fa-history consumer
+cd fa-history
+pip install -r requirements.txt
+python run.py
+
+# Expected output:
+# [history-consumer] started. queue=fa-history.events exchange=fa.events rk=post.*
+# * Running on http://127.0.0.1:3004
+```
+
+#### 2.2 Start fa-post Producer Service
+
+```bash
+# Terminal 2: Start fa-post producer
+cd fa-post
+npm install
+npm run dev
+
+# Expected output:
+# Database connected.
+# [rabbit] connected. exchange=fa.events type=topic
+# Post service on :3002
+```
+
+#### 2.3 Verify Services are Running
+
+```bash
+# Check fa-post health
+curl http://localhost:3002/api/posts
+# Should return 401 (auth required) - service is running
+
+# Check fa-history health
+curl http://localhost:3004/health
+# Should return 200 OK
+
+# Check RabbitMQ Management UI
+open http://localhost:15672
+# Login: guest/guest
+# Verify exchange 'fa.events' exists
+# Verify queue 'fa-history.events' exists and is bound
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,15 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "amqplib": "^0.10.9",
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.1",
         "mysql2": "^3.14.5",
-        "sequelize": "^6.37.7"
+        "sequelize": "^6.37.7",
+        "uuid": "^13.0.0"
       }
     },
     "node_modules/@types/debug": {
@@ -59,6 +61,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/amqplib": {
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.9.tgz",
+      "integrity": "sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "url-parse": "~1.5.10"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/aws-ssl-profiles": {
@@ -113,6 +128,12 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -984,6 +1005,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1023,6 +1050,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/retry-as-promised": {
       "version": "7.1.1",
@@ -1182,6 +1215,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/sequelize/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/serve-static": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
@@ -1337,13 +1379,27 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validator": {

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
   },
   "homepage": "https://github.com/forum-app-team/fa-post#readme",
   "dependencies": {
-    "express": "^5.1.0",
-    "sequelize": "^6.37.7",
-    "mysql2": "^3.14.5",
-    "jsonwebtoken": "^9.0.2",
+    "amqplib": "^0.10.9",
     "cors": "^2.8.5",
+    "dotenv": "^17.2.2",
+    "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.1",
-    "dotenv": "^17.2.2"
+    "mysql2": "^3.14.5",
+    "sequelize": "^6.37.7",
+    "uuid": "^13.0.0"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -5,7 +5,10 @@ import postsRouter from './routes/posts.js';
 import { errorHandler } from './middleware/errors.js';
 
 const app = express();
-app.use(cors());
+app.use(cors({
+  origin: ['http://localhost:5173', 'http://localhost:5174', 'http://localhost:3000'],
+  credentials: true
+}));
 app.use(express.json());
 app.use(morgan('dev'));
 

--- a/src/messaging/events.js
+++ b/src/messaging/events.js
@@ -1,0 +1,48 @@
+import { v4 as uuidv4 } from 'uuid';
+import { publishEvent } from './rabbit.js';
+
+function pickPostSnapshot(post) {
+  return {
+    status: post.status,
+    isArchived: !!post.isArchived,
+    title: post.title,
+    content: post.content,
+    images: post.images || [],
+    attachments: post.attachments || [],
+  };
+}
+
+export function buildPostEvent(req, eventType, post, before = null, after = null) {
+  const correlationId = req.headers['x-correlation-id'] || req.headers['x-request-id'] || uuidv4();
+  const traceId = req.headers['x-request-id'] || correlationId;
+  const eventId = uuidv4();
+  return {
+    eventId,
+    eventType,
+    occurredAt: new Date().toISOString(),
+    userId: req.user?.sub,
+    postId: String(post.id),
+    before,
+    after,
+    correlationId,
+    traceId,
+    service: 'fa-post',
+    version: 1,
+  };
+}
+
+export async function emitPostEvent(req, eventType, post, before = null, after = null) {
+  const payload = buildPostEvent(
+    req,
+    eventType,
+    post,
+    before === 'SNAPSHOT' ? pickPostSnapshot(post) : before,
+    after === 'SNAPSHOT' ? pickPostSnapshot(post) : after
+  );
+  try {
+    await publishEvent(eventType, payload, { correlationId: payload.correlationId });
+  } catch (e) {
+    // Swallow to avoid impacting API response path
+  }
+}
+

--- a/src/messaging/rabbit.js
+++ b/src/messaging/rabbit.js
@@ -1,0 +1,70 @@
+import amqp from 'amqplib';
+
+let connection = null;
+let channel = null;
+
+const RABBITMQ_URL = process.env.RABBITMQ_URL || 'amqp://guest:guest@localhost:5672/';
+const EXCHANGE = process.env.RABBITMQ_EVENTS_EXCHANGE || 'fa.events';
+const EXCHANGE_TYPE = process.env.RABBITMQ_EVENTS_EXCHANGE_TYPE || 'topic';
+
+export async function initRabbit() {
+  try {
+    connection = await amqp.connect(RABBITMQ_URL);
+    connection.on('error', (e) => console.error('[rabbit] connection error', e.message));
+    connection.on('close', () => console.warn('[rabbit] connection closed'));
+
+    channel = await connection.createConfirmChannel();
+    await channel.assertExchange(EXCHANGE, EXCHANGE_TYPE, { durable: true });
+    console.log(`[rabbit] connected. exchange=${EXCHANGE} type=${EXCHANGE_TYPE}`);
+  } catch (err) {
+    console.warn('[rabbit] init failed (continuing without MQ):', err?.message);
+    connection = null;
+    channel = null;
+  }
+}
+
+export function isRabbitReady() {
+  return !!channel;
+}
+
+export async function publishEvent(routingKey, payload, opts = {}) {
+  if (!channel) return false;
+  try {
+    const props = {
+      contentType: 'application/json',
+      deliveryMode: 2, // persistent
+      correlationId: opts.correlationId,
+      messageId: payload?.eventId,
+      timestamp: Math.floor(Date.now() / 1000),
+      headers: opts.headers || {},
+    };
+    await new Promise((resolve, reject) => {
+      const ok = channel.publish(
+        EXCHANGE,
+        routingKey,
+        Buffer.from(JSON.stringify(payload)),
+        props,
+        (err) => (err ? reject(err) : resolve(true))
+      );
+      if (!ok) {
+        // backpressure – still wait for confirm callback
+      }
+    });
+    return true;
+  } catch (err) {
+    console.error('[rabbit] publish error:', err?.message);
+    return false;
+  }
+}
+
+export async function closeRabbit() {
+  try {
+    if (channel) await channel.close();
+  } catch {}
+  try {
+    if (connection) await connection.close();
+  } catch {}
+  channel = null;
+  connection = null;
+}
+


### PR DESCRIPTION
## Description:
fa-post publishes durable topic events to RabbitMQ for all required post lifecycle changes

### Changes:
- Added dependencies
Installed: amqplib, uuid
- New messaging utilities
src/messaging/rabbit.js
src/messaging/events.js
- Event emissions in controllers
src/controllers/posts.controller.js now emits:
post.created
post.published
post.updated
post.archived
post.unarchived
post.banned
post.unbanned
post.deleted
post.recovered
- Startup wiring
src/index.js initializes RabbitMQ (non‑fatal if unavailable) and closes gracefully on shutdown
- Environment
README updated to include producer env vars